### PR TITLE
feat: Julia helper functions using PyCall

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           project: .
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.12
+      # - name: Set up Python
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: 3.12
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,8 +67,8 @@ jobs:
         run: |
           python -m pip install -r requirements/pycall.txt
 
-      # - name: Run Python tests
-      #   run: python test/test.py
+      - name: Run PyCall tests
+        run: julia --project=tests test/runpytests.jl
 
       - name: Generate and upload code coverage
         uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Build Julia package
         uses: julia-actions/julia-buildpkg@v1
 
-      - name: Install PyCall dependencies
-        run: julia -e 'import Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
-
       - name: Run Julia tests
         uses: julia-actions/julia-runtest@v1
         with:
@@ -67,6 +64,9 @@ jobs:
         run: |
           python -m pip install -r requirements/pycall.txt
 
+      - name: Install PyCall dependencies
+        run: julia -e 'import Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
+  
       - name: Run PyCall tests
         run: julia --project=tests test/runpytests.jl
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
         run: julia -e 'import Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
   
       - name: Run PyCall tests
-        run: julia --project=tests test/runpytests.jl
+        run: julia --code-coverage --project=tests test/runpytests.jl
 
       - name: Generate and upload code coverage
         uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,11 +55,6 @@ jobs:
         with:
           project: .
 
-      # - name: Set up Python
-      #   uses: actions/setup-python@v2
-      #   with:
-      #     python-version: 3.12
-
       - name: Install Python dependencies
         run: |
           python -m pip install -r requirements/pycall.txt

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -1,21 +1,8 @@
 module AwkwardPyCall
-
-using Pkg
-
-isinstalled(pkg::String) = any(x -> x.name == pkg && x.is_direct_dep, values(Pkg.dependencies()))
-
-if !isinstalled("PyCall")
-    println("PyCall is not installed. Installing...")
-
-    import Pkg
-
-    Pkg.add("PyCall")
-end
     
 using PyCall
-
 using JSON
-@reexport using AwkwardArray
+using AwkwardArray
 
 const ak = pyimport("awkward")
 const np = pyimport("numpy")

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -30,3 +30,5 @@ function julia_array_to_python(array)
 
     return ak.from_buffers(form, len, py_buffers)
 end
+
+end # module

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -1,5 +1,5 @@
 module AwkwardPyCall
-    
+
 using PyCall
 using JSON
 using AwkwardArray
@@ -9,13 +9,13 @@ const np = pyimport("numpy")
 
 function _as_numpy(array::AbstractVector{UInt8})
     py_array = PyObject(array)
-    np.asarray(py_array, dtype=np.uint8)
+    np.asarray(py_array, dtype = np.uint8)
 end
 
 function julia_array_to_python(array)
     form, len, containers = AwkwardArray.to_buffers(array)
-    
-    py_buffers = Dict{String, Any}()
+
+    py_buffers = Dict{String,Any}()
 
     for (key, buffer) in containers
         py_buffers[key] = _as_numpy(buffer)
@@ -32,7 +32,7 @@ end
 function python_array_to_julia(py_array)
     form, len, containers = ak.to_buffers(py_array)
 
-    julia_buffers = Dict{String, AbstractVector{UInt8}}()
+    julia_buffers = Dict{String,AbstractVector{UInt8}}()
     for (key, buffer) in containers
         julia_buffers[key] = _as_julia(buffer)
     end

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -9,6 +9,7 @@ if !isdefined(Main, :PyCall)
 end
     
 using PyCall
+using JSON
 @reexport using AwkwardArray
 
 const ak = pyimport("awkward")

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -25,10 +25,26 @@ function julia_array_to_python(array)
     py_buffers = Dict{String, Any}()
 
     for (key, buffer) in containers
-        numpy_arrays[key] = _as_numpy(buffer)
+        py_buffers[key] = _as_numpy(buffer)
     end
 
     return ak.from_buffers(form, len, py_buffers)
+end
+
+function _as_julia(py_buffer)
+    uint8_buffer = reinterpret(UInt8, py_buffer)
+    return uint8_buffer
+end
+
+function python_array_to_julia(py_array)
+    form, len, containers = ak.to_buffers(py_array)
+
+    julia_buffers = Dict{String, AbstractVector{UInt8}}()
+    for (key, buffer) in containers
+        julia_buffers[key] = _as_julia(buffer)
+    end
+
+    return AwkwardArray.from_buffers(form.to_json(), len, julia_buffers)
 end
 
 end # module

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -9,7 +9,7 @@ if !isdefined(Main, :PyCall)
 end
     
 using PyCall
-using AwkwardArray
+@reexport using AwkwardArray
 
 const ak = pyimport("awkward")
 const np = pyimport("numpy")

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -13,6 +13,7 @@ if !isinstalled("PyCall")
 end
     
 using PyCall
+
 using JSON
 @reexport using AwkwardArray
 

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -1,6 +1,10 @@
 module AwkwardPyCall
 
-if !isdefined(Main, :PyCall)
+using Pkg
+
+isinstalled(pkg::String) = any(x -> x.name == pkg && x.is_direct_dep, values(Pkg.dependencies()))
+
+if !isinstalled("PyCall")
     println("PyCall is not installed. Installing...")
 
     import Pkg

--- a/src/pycall/AwkwardPyCall.jl
+++ b/src/pycall/AwkwardPyCall.jl
@@ -1,3 +1,5 @@
+module AwkwardPyCall
+
 if !isdefined(Main, :PyCall)
     println("PyCall is not installed. Installing...")
 

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,4 +1,6 @@
-if !haskey(Pkg.installed(), "PyCall")
+import Pkg
+
+if !haskey(Pkg.installed(), "PyCall") # FIXME: Pkg.installed() is deprecated!
     println("PyCall is not installed. Installing...")
     Pkg.add("PyCall")
 end

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -18,7 +18,7 @@ function julia_array_to_python(array)
     numpy_arrays = Dict{String, Any}()
 
     for (key, value) in containers
-        numpy_arrays[key] = np.array(value, dtype=np.uint8)
+        numpy_arrays[key] = np.asarray(value, dtype=np.uint8)
     end
 
     ### a bytes-like object is required

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,0 +1,25 @@
+using PyCall
+using AwkwardArray
+
+const ak = pyimport("awkward")
+const np = pyimport("numpy")
+
+function julia_array_to_numpy(array)
+    py_array = PyObject(array)
+    np.array(py_array)
+end
+
+### convert a Julia AwkwardArray to a Python Awkward Array
+### via buffers
+function julia_array_to_python(array)
+    form, len, containers = AwkwardArray.to_buffers(array)
+    
+    numpy_arrays = Dict{String, Any}()
+
+    for (key, value) in containers
+        numpy_arrays[key] = np.array(value, dtype=np.uint8)
+    end
+
+    ### a bytes-like object is required
+    return ak.from_buffers(form, len, numpy_arrays)
+end

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -6,7 +6,7 @@ const np = pyimport("numpy")
 
 function _as_numpy(array::AbstractVector{UInt8})
     py_array = PyObject(array)
-    np.array(py_array, dtype=np.uint8)
+    np.asarray(py_array, dtype=np.uint8)
 end
 
 function julia_array_to_python(array)

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,10 +1,11 @@
 using PyCall
 using AwkwardArray
+using AwkwardArray: PrimitiveArray
 
 const ak = pyimport("awkward")
 const np = pyimport("numpy")
 
-function julia_array_to_numpy(array)
+function julia_array_to_numpy(array::PrimitiveArray)
     py_array = PyObject(array)
     np.array(py_array)
 end

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,26 +1,22 @@
 using PyCall
 using AwkwardArray
-using AwkwardArray: PrimitiveArray
 
 const ak = pyimport("awkward")
 const np = pyimport("numpy")
 
-function julia_array_to_numpy(array::PrimitiveArray)
+function _as_numpy(array::AbstractVector{UInt8})
     py_array = PyObject(array)
-    np.array(py_array)
+    np.array(py_array, dtype=np.uint8)
 end
 
-### convert a Julia AwkwardArray to a Python Awkward Array
-### via buffers
 function julia_array_to_python(array)
     form, len, containers = AwkwardArray.to_buffers(array)
     
-    numpy_arrays = Dict{String, Any}()
+    py_buffers = Dict{String, Any}()
 
-    for (key, value) in containers
-        numpy_arrays[key] = np.asarray(value, dtype=np.uint8)
+    for (key, buffer) in containers
+        numpy_arrays[key] = _as_numpy(buffer)
     end
 
-    ### a bytes-like object is required
-    return ak.from_buffers(form, len, numpy_arrays)
+    return ak.from_buffers(form, len, py_buffers)
 end

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,3 +1,8 @@
+if !haskey(Pkg.installed(), "PyCall")
+    println("PyCall is not installed. Installing...")
+    Pkg.add("PyCall")
+end
+    
 using PyCall
 using AwkwardArray
 

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,7 +1,8 @@
-import Pkg
-
 if !isdefined(Main, :PyCall)
     println("PyCall is not installed. Installing...")
+
+    import Pkg
+
     Pkg.add("PyCall")
 end
     

--- a/src/pycall/julia_helpers.jl
+++ b/src/pycall/julia_helpers.jl
@@ -1,6 +1,6 @@
 import Pkg
 
-if !haskey(Pkg.installed(), "PyCall") # FIXME: Pkg.installed() is deprecated!
+if !isdefined(Main, :PyCall)
     println("PyCall is not installed. Installing...")
     Pkg.add("PyCall")
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -4,11 +4,12 @@ Tables.columnaccess(::Type{RecordArray}) = true
 Tables.columns(x::RecordArray) = x.contents
 Tables.columnnames(x::RecordArray) = keys(x.contents)
 
-Tables.schema(x::RecordArray) = Tables.Schema(Tables.columnnames(x), eltype.(values(Tables.columns(x))))
+Tables.schema(x::RecordArray) =
+    Tables.Schema(Tables.columnnames(x), eltype.(values(Tables.columns(x))))
 
 function from_table(input)
     sch = Tables.schema(input)
-    NT = NamedTuple{sch.names, Base.Tuple{sch.types...}}
+    NT = NamedTuple{sch.names,Base.Tuple{sch.types...}}
     AwkwardType = layout_for(NT)
     out = AwkwardType()
 
@@ -18,4 +19,3 @@ function from_table(input)
 
     return out
 end
-

--- a/test/runpytests.jl
+++ b/test/runpytests.jl
@@ -4,24 +4,26 @@ using AwkwardArray
 
 include("../src/pycall/AwkwardPyCall.jl")
 
+import Main.AwkwardPyCall: ak
+
 import Main.AwkwardPyCall: julia_array_to_python
 
 # Test julia_array_to_python function
 @testset "julia_array_to_python tests" begin
-    layout = AwkwardArray.ListOffsetArray(
+    array = AwkwardArray.ListOffsetArray(
             [0, 3, 3, 5],
             AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
         )
     # Test case 1: Check if the function returns an awkward array
-    @test isa(julia_array_to_python(layout), PyObject)
+    @test isa(julia_array_to_python(array), PyObject)
 
-    # Test case 2: Check if the awkward array has the correct dtype
-    py_array = julia_array_to_python(layout)
+    # Test case 2: Check if the awkward array has the correct layout
+    py_array = julia_array_to_python(array)
     @test typeof(py_array) == PyObject
+    @test ak.to_list(py_array) == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 end
 
 import Main.AwkwardPyCall: python_array_to_julia
-import Main.AwkwardPyCall: ak
 
 # Test python_array_to_julia function
 @testset "python_array_to_julia tests" begin
@@ -30,7 +32,8 @@ import Main.AwkwardPyCall: ak
     # Test case 1: Check if the function returns an awkward array
     @test isa(python_array_to_julia(py_array), AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default})
 
-    # Test case 2: Check if the awkward array has the correct dtype
+    # Test case 2: Check if the awkward array has the correct layout
     array = python_array_to_julia(py_array)
     @test typeof(array) == AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default}
+    @test array == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 end

--- a/test/runpytests.jl
+++ b/test/runpytests.jl
@@ -1,0 +1,36 @@
+using PyCall
+using Test
+using AwkwardArray
+
+include("../src/pycall/AwkwardPyCall.jl")
+
+import Main.AwkwardPyCall: julia_array_to_python
+
+# Test julia_array_to_python function
+@testset "julia_array_to_python tests" begin
+    layout = AwkwardArray.ListOffsetArray(
+            [0, 3, 3, 5],
+            AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
+        )
+    # Test case 1: Check if the function returns an awkward array
+    @test isa(julia_array_to_python(layout), PyObject)
+
+    # Test case 2: Check if the awkward array has the correct dtype
+    py_array = julia_array_to_python(layout)
+    @test typeof(py_array) == PyObject
+end
+
+import Main.AwkwardPyCall: python_array_to_julia
+import Main.AwkwardPyCall: ak
+
+# Test python_array_to_julia function
+@testset "python_array_to_julia tests" begin
+    py_array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
+ 
+    # Test case 1: Check if the function returns an awkward array
+    @test isa(python_array_to_julia(py_array), AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default})
+
+    # Test case 2: Check if the awkward array has the correct dtype
+    array = python_array_to_julia(py_array)
+    @test typeof(array) == AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default}
+end

--- a/test/runpytests.jl
+++ b/test/runpytests.jl
@@ -1,5 +1,20 @@
 using PyCall
 using Test
+
+using Pkg
+
+# FIXME: remove after AwkwardArray is released
+function add_unreleased_AwkwardArray_package()
+    # Specify the Git URL of the AwkwardArray package
+    git_url = "https://github.com/JuliaHEP/AwkwardArray.jl"
+    
+    # Use Pkg to add the package
+    Pkg.add(PackageSpec(url=git_url))
+end
+
+# Call the function to add the unreleased AwkwardArray package
+add_unreleased_AwkwardArray_package()
+
 using AwkwardArray
 
 include("../src/pycall/AwkwardPyCall.jl")

--- a/test/runpytests.jl
+++ b/test/runpytests.jl
@@ -17,6 +17,9 @@ add_unreleased_AwkwardArray_package()
 
 using AwkwardArray
 
+Pkg.add("JSON")
+using JSON
+
 include("../src/pycall/AwkwardPyCall.jl")
 
 import Main.AwkwardPyCall: ak

--- a/test/runpytests.jl
+++ b/test/runpytests.jl
@@ -7,9 +7,9 @@ using Pkg
 function add_unreleased_AwkwardArray_package()
     # Specify the Git URL of the AwkwardArray package
     git_url = "https://github.com/JuliaHEP/AwkwardArray.jl"
-    
+
     # Use Pkg to add the package
-    Pkg.add(PackageSpec(url=git_url))
+    Pkg.add(PackageSpec(url = git_url))
 end
 
 # Call the function to add the unreleased AwkwardArray package
@@ -29,9 +29,9 @@ import Main.AwkwardPyCall: julia_array_to_python
 # Test julia_array_to_python function
 @testset "julia_array_to_python tests" begin
     array = AwkwardArray.ListOffsetArray(
-            [0, 3, 3, 5],
-            AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
-        )
+        [0, 3, 3, 5],
+        AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
+    )
     # Test case 1: Check if the function returns an awkward array
     @test isa(julia_array_to_python(array), PyObject)
 
@@ -46,12 +46,31 @@ import Main.AwkwardPyCall: python_array_to_julia
 # Test python_array_to_julia function
 @testset "python_array_to_julia tests" begin
     py_array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
- 
+
     # Test case 1: Check if the function returns an awkward array
-    @test isa(python_array_to_julia(py_array), AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default})
+    @test isa(
+        python_array_to_julia(py_array),
+        AwkwardArray.ListOffsetArray{
+            SubArray{Int64,1,Vector{Int64},Tuple{UnitRange{Int64}},true},
+            AwkwardArray.PrimitiveArray{
+                Float64,
+                SubArray{Float64,1,Vector{Float64},Tuple{UnitRange{Int64}},true},
+                :default,
+            },
+            :default,
+        },
+    )
 
     # Test case 2: Check if the awkward array has the correct layout
     array = python_array_to_julia(py_array)
-    @test typeof(array) == AwkwardArray.ListOffsetArray{SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{Int64}}, true}, AwkwardArray.PrimitiveArray{Float64, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, :default}, :default}
+    @test typeof(array) == AwkwardArray.ListOffsetArray{
+        SubArray{Int64,1,Vector{Int64},Tuple{UnitRange{Int64}},true},
+        AwkwardArray.PrimitiveArray{
+            Float64,
+            SubArray{Float64,1,Vector{Float64},Tuple{UnitRange{Int64}},true},
+            :default,
+        },
+        :default,
+    }
     @test array == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using JSON
 using Test
 using Tables
 
-    ### PrimitiveArray #######################################################
+### PrimitiveArray #######################################################
 @testset "PrimitiveArray" begin
 
     begin
@@ -116,7 +116,7 @@ end
     end
 end
 
-    ### ListOffsetArray ######################################################
+### ListOffsetArray ######################################################
 @testset "ListOffsetArray" begin
 
     begin
@@ -233,7 +233,7 @@ end
     end
 end
 
-    ### ListArray ######################################################
+### ListArray ######################################################
 @testset "ListArray" begin
 
     begin
@@ -355,7 +355,7 @@ end
     end
 end
 
-    ### RegularArray #########################################################
+### RegularArray #########################################################
 
 @testset "RegularArray" begin
     begin
@@ -543,7 +543,7 @@ end
     end
 end
 
-    ### ListType with behavior = :string #####################################
+### ListType with behavior = :string #####################################
 
 @testset "ListType with behavior = :string" begin
     begin
@@ -900,7 +900,7 @@ end
     end
 
 end
-    ### ListType with other parameters #######################################
+### ListType with other parameters #######################################
 
 @testset "ListType with other parameters" begin
     begin
@@ -984,7 +984,7 @@ end
     end
 end
 
-    ### RecordArray ##########################################################
+### RecordArray ##########################################################
 
 @testset "RecordArray" begin
     begin
@@ -1282,7 +1282,7 @@ end
         )
     end
 end
-    ### TupleArray ##########################################################
+### TupleArray ##########################################################
 
 @testset "TupleArray" begin
     begin
@@ -1540,7 +1540,7 @@ end
     end
 end
 
-    ### IndexedArray #########################################################
+### IndexedArray #########################################################
 
 @testset "IndexedArray" begin
     begin
@@ -1709,7 +1709,7 @@ end
     end
 end
 
-    ### IndexedOptionArray ###################################################
+### IndexedOptionArray ###################################################
 
 @testset "IndexedOptionArray" begin
     begin
@@ -1826,7 +1826,7 @@ end
     end
 end
 
-    ### ByteMaskedArray ######################################################
+### ByteMaskedArray ######################################################
 
 @testset "ByteMaskedArray" begin
     begin
@@ -1984,7 +1984,7 @@ end
     end
 end
 
-    ### BitMaskedArray #######################################################
+### BitMaskedArray #######################################################
 
 @testset "BitMaskedArray" begin
     begin
@@ -2141,7 +2141,7 @@ end
     end
 end
 
-    ### UnmaskedArray ########################################################
+### UnmaskedArray ########################################################
 
 @testset "UnmaskedArray" begin
     begin
@@ -2270,7 +2270,7 @@ end
         )
     end
 end
-    ### UnionArray ###########################################################
+### UnionArray ###########################################################
 
 @testset "UnionArray" begin
     begin
@@ -2437,7 +2437,7 @@ end
         )
     end
 end
-    ### from_iter ############################################################
+### from_iter ############################################################
 
 @testset "from_iter" begin
     begin
@@ -2517,7 +2517,7 @@ end
     end
 end
 
-    ### from_buffers #########################################################
+### from_buffers #########################################################
 
 @testset "from_buffers" begin
     begin
@@ -3159,7 +3159,7 @@ end
     end
 
     @testset "Tables.jl intergration" begin
-        df = (; x = [[1], [2], [1,2,3]], y = [4.0, 5, 6])
+        df = (; x = [[1], [2], [1, 2, 3]], y = [4.0, 5, 6])
         awt = AwkwardArray.from_table(df)
         @test Tables.schema(df) == Tables.schema(awt)
 


### PR DESCRIPTION
* a helper to convert Julia Awkward array to Python:
```julia
julia> array
3-element AwkwardArray.ListOffsetArray{Vector{Int64}, AwkwardArray.PrimitiveArray{Int64, Vector{Int64}, :default}, :default}:
 [1, 2, 3]
 [4]
 [5, 6, 7]

julia> ak_array = julia_array_to_python(array)
PyObject <Array [[1, 2, 3], [4], [5, 6, 7]] type='3 * var * int64'>

julia> ak.sum(ak_array)
28
```