### PR TITLE
chore: version 0.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AwkwardArray"
 uuid = "7d259134-7f60-4bf1-aa00-7452e11bde56"
 authors = ["Jim Pivarski <pivarski@princeton.edu>", "Jerry Ling <jerry.ling@cern.ch>", "and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"


### PR DESCRIPTION
The version specified in `Project.toml` must not exist as a tag when one registers a new version. The workflow is to add the tag after the registration/update is successful (merged).