### PR TITLE
chore: set a [compat] Conda entry that is upper-bounded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+Conda = "1.10.0"
 JSON = "0.21.4"
 PythonCall = "0.9"
 Tables = "1.11.1"


### PR DESCRIPTION
The Conda dependency did not have a [compat] entry that is upper-bounded and only included a finite number of breaking releases: Conda