### PR TITLE
reduce allocation in Record array construction

### DIFF
--- a/src/all_implementations.jl
+++ b/src/all_implementations.jl
@@ -1931,11 +1931,11 @@ RecordArray(
     behavior::Symbol = :default,
 ) where {FIELDS,CONTENTS<:Base.Tuple{Vararg{Content}}} = RecordArray(
     contents,
-    minimum(if length(contents) == 0
+    if isempty(contents)
         0
     else
-        [length(x) for x in contents]
-    end),
+        minimum(length, contents)
+    end,
     parameters = parameters,
     behavior = behavior,
 )


### PR DESCRIPTION
```julia
#before 
julia> @b AwkwardArray.RecordArray((;x=AwkwardArray.PrimitiveArray([1,2,3])))
126.453 ns (7 allocs: 272 bytes)

#after
julia> @b AwkwardArray.RecordArray((;x=AwkwardArray.PrimitiveArray([1,2,3])))
18.722 ns (3 allocs: 144 bytes)
```