### PR TITLE
chore: pivarski@princeton.edu -> jpivarski@gmail.com

### DIFF
--- a/docs/src/LICENSE.md
+++ b/docs/src/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jim Pivarski <pivarski@princeton.edu>, Jerry Ling <jerry.ling@cern.ch>, and contributors
+Copyright (c) 2023 Jim Pivarski <jpivarski@gmail.com>, Jerry Ling <jerry.ling@cern.ch>, and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Because my GMail address is permanent.