### PR TITLE
add Primitive and ListOffsetArray adapts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,15 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extensions]
 AwkwardPythonCallExt = "PythonCall"
+AwkwardAdaptExt = "Adapt"
 
 [compat]
+Adapt = "4.3.0"
 Conda = "1.10.0"
 JSON = "0.21.4"
 PythonCall = "0.9"

--- a/ext/AwkwardAdaptExt.jl
+++ b/ext/AwkwardAdaptExt.jl
@@ -1,0 +1,16 @@
+module AwkwardAdaptExt
+
+import Adapt
+import AwkwardArray as ak
+
+function Adapt.adapt_structure(to, x::ak.PrimitiveArray{I, T, B}) where {I, T, B}
+    ak.PrimitiveArray(Adapt.adapt(to, x.data); x.parameters, behavior = B)
+end
+
+function Adapt.adapt_structure(to, x::ak.ListOffsetArray{I, T, B}) where {I, T, B}
+    new_offsets = Adapt.adapt(to, x.offsets)
+    new_content = Adapt.adapt(to, x.content)
+    ak.ListOffsetArray(new_offsets, new_content; x.parameters, behavior = B)
+end
+
+end


### PR DESCRIPTION
```julia
julia> using AwkwardArray, Adapt, CUDA

julia> a = [rand(rand(1:10)) for _ in 1:5];

julia> offsetlist = ak.from_iter(a)
5-element AwkwardArray.ListOffsetArray{Vector{Int64}, AwkwardArray.PrimitiveArray{Float64, Vector{Float64}, :default}, :default}:
 [0.3893672498306302, 0.4460913595389929, ..., 0.057796016079792345]
 [0.9841042526444175, 0.9950665714461073, ..., 0.2238581936838373]
 [0.7771696340731816]
 [0.2385677791734916, 0.005399224600258767, ..., 0.7011812867589344]
 [0.06884029167153738, 0.28108772427116335, ..., 0.34110713672124804]

julia> cu_offsetlist = adapt(CuArray, offsetlist); # display is broken because we try to do scalar indexing on GPU array...
```